### PR TITLE
Update 09.markmin

### DIFF
--- a/sources/29-web2py-english/09.markmin
+++ b/sources/29-web2py-english/09.markmin
@@ -638,7 +638,6 @@ class FaceBookAccount(OAuthAccount):
     def __init__(self):
         OAuthAccount.__init__(self, None, FB_CLIENT_ID, FB_CLIENT_SECRET,
                               self.AUTH_URL, self.TOKEN_URL,
-                              scope='email,user_about_me,user_activities, user_birthday, user_education_history, user_groups, user_hometown, user_interests, user_likes, user_location, user_relationships, user_relationship_details, user_religion_politics, user_subscriptions, user_work_history, user_photos, user_status, user_videos, publish_actions, friends_hometown, friends_location,friends_photos',
                               state="auth_provider=facebook",
                               display='popup')
         self.graph = None
@@ -654,7 +653,8 @@ class FaceBookAccount(OAuthAccount):
 
         user = None
         try:
-            user = self.graph.get_object("me")
+            args = {'fields' : 'id,name,email,first_name,last_name'}
+            user = self.graph.get_object("me", **args)
         except GraphAPIError, e:
             session.token = None
             self.graph = None


### PR DESCRIPTION
I removed the "scope=... " line which produced errors and seems redundant now. 
I added **args for first_name etc which seems to be how facebook does it now. (from stackoverflow.com/questions/16669977)
I tested the code on my server and it seems to work unlike the previous which gave errors.

(I was trying to use the code in the web2py book for facebook login and it didn't work, presumably because facebook changed their API. The above changes got it working.)